### PR TITLE
Make post dates use an int

### DIFF
--- a/posts.go
+++ b/posts.go
@@ -320,9 +320,9 @@ func PostsRecent(opt *PostsRecentOptions) ([]*Post, error) {
 
 // postsDatesResponse represents the response from /posts/dates.
 type postsDatesResponse struct {
-	User  string            `json:"user"`
-	Tag   string            `json:"tag"`
-	Dates map[string]string `json:"dates"`
+	User  string         `json:"user"`
+	Tag   string         `json:"tag"`
+	Dates map[string]int `json:"dates"`
 }
 
 // PostsDatesOptions represents the single optional argument for
@@ -336,7 +336,7 @@ type PostsDatesOptions struct {
 // date.
 //
 // https://pinboard.in/api/#posts_dates
-func PostsDates(opt *PostsDatesOptions) (map[string]string, error) {
+func PostsDates(opt *PostsDatesOptions) (map[string]int, error) {
 	resp, err := get("postsDates", opt)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes: #2 

I realize this is a breaking change since it changes the return type of the exported `PostDates` function from `(map[string]string, error)` to `(map[string]int, error)`.. although since the previous version would always return an error, it seems this should be ok to merge and release a new version?

## Testing

When running locally using a go mod replace directive with my fork:

```
replace github.com/imwally/pinboard v1.0.2 => github.com/markphelps/pinboard post-dates-int
```

I get the correct results, no error:

```go
dates, err := pinboard.PostsDates(&pinboard.PostsDatesOptions{})
if err != nil {
  l.Fatal(err)
}

l.Debugf("%+v", dates)
```

```shell
map[2020-10-02:87 2020-10-10:2 2020-10-12:1 2021-02-21:1 2021-05-30:1 2021-06-15:1 2021-07-08:2 2021-07-26:1 2021-08-05:1 2021-08-25:1 2021-08-28:2]
```